### PR TITLE
add small details about interfaces and fix a small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ curl -SLs https://get.arkade.dev | sudo sh
 sudo arkade system install firecracker
 ```
 
-Edit the `IFNAME` in `setup-networking.sh` to match your host's network interface.
+Edit the `IFNAME` in `setup-networking.sh` to match your host's network interface. If you
+have trouble identifying which one to use, look for the interface with both "inet" and "ether",
+not just "ether", since you need to be able forward packets from the tap interface to the
+internet.
 
 Then run the script to create the ftap0 device, and to setup IP masquerading with iptables:
 

--- a/boot.sh
+++ b/boot.sh
@@ -14,7 +14,7 @@ sudo curl --unix-socket /tmp/firecracker.socket -i \
             \"boot_args\": \"console=ttyS0 reboot=k panic=1 pci=off init=/init ip=172.16.0.2::172.16.0.1:255.255.255.0::eth0:off\" 
        }"
        
-# Configure a network device, notice the host_dev_name macthes what 
+# Configure a network device, notice the host_dev_name matches what
 # we set in setup_networking.sh
 
 sudo curl -X PUT \

--- a/setup-networking.sh
+++ b/setup-networking.sh
@@ -17,7 +17,9 @@ ip addr show dev ftap0
 
 # Change IFNAME to match your main ethernet adapter, the one that
 # accesses the Internet - check "ip addr" or "ifconfig" if you don't 
-# know which one to use.
+# know which one to use. It will be the one with both "inet" and
+# "ether", not the one with just "ether", since it needs to forward
+# packets to the internet.
 IFNAME=enp8s0
 
 # Enable IP forwarding


### PR DESCRIPTION
While walking through this lab (which is fantastic, btw!), I got tripped up assuming that I needed to add an interface that was called something like the example (`enp8s0`), and I missed confirming that that particular interface wasn't connected to the internet. So I added one that had a similar name (starting with `enp`) and got stuck during the step to add a nameserver and then ping 8.8.8.8.

After trying to debug it a bit, I worked out that I might have the wrong interface associated, and so I tried the wlan one, and that seemed to work.

This PR adds more details that hopefully help the next person find the correct interface easier. It also fixes a minor typo.