### PR TITLE
fix: 1024 mib memory

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -13,8 +13,19 @@ sudo curl --unix-socket /tmp/firecracker.socket -i \
             \"kernel_image_path\": \"./vmlinux\", 
             \"boot_args\": \"console=ttyS0 reboot=k panic=1 pci=off init=/init ip=172.16.0.2::172.16.0.1:255.255.255.0::eth0:off\" 
        }"
+
+# Configure memory and vCPUs
+sudo curl --unix-socket /tmp/firecracker.socket -i \
+    -X PUT 'http://localhost/machine-config' \
+    -H 'Accept: application/json'           \
+    -H 'Content-Type: application/json'     \
+    -d '{
+        "vcpu_count": 1,
+        "mem_size_mib": 1024
+    }'
+
        
-# Configure a network device, notice the host_dev_name macthes what 
+# Configure a network device, notice the host_dev_name matches what 
 # we set in setup_networking.sh
 
 sudo curl -X PUT \


### PR DESCRIPTION
Hi! 

First of all, thank you for this awesome repo. I tried to get everything running, but the `curl -i https://inlets.dev`step always failed, I assume because the default firecracker vm only has ~100MB of free memory. As soon as I increased the limit everything worked perfectly fine.

I added a call to machine-config with 1024 MiB memory to the boot.sh file. Also fixed a small typo.

Feel free to close this PR if you don't think this is needed:)

Cheers, Jonas